### PR TITLE
Implement C++ coverage report

### DIFF
--- a/.github/workflows/gseim-ci.yml
+++ b/.github/workflows/gseim-ci.yml
@@ -18,17 +18,18 @@ jobs:
         run: |
           sudo apt install libgirepository1.0-dev libcairo2-dev pkg-config gir1.2-gtk-3.0 qtbase5-dev libxkbcommon-x11-0
           pip3 install pyqt5
-      - name: Run Bazel test
+      - name: Run Bazel test and generate coverage report
         run: |
           mkdir ~/.cache/gseim/
           chmod 777 ~/.cache/gseim/
-          bazel test //...
+          bazel coverage //...
+          cp $(bazel info output_path)/_coverage/_coverage_report.dat /home/runner/work/gseim/gseim/coverage_report.dat
       - name: Build Linux wheel
         run: |
           bazel build //:gseim_wheel
           # This is required due to https://github.com/actions/upload-artifact/issues/92.
           cp bazel-bin/gseim-*.whl /home/runner/work/gseim/gseim
-      - name: Try installing wheel
+      - name: Try installing and running wheel
         run: |
           pip3 install gseim-*.whl
           `python3 -c "import gseim_cpp_lib; from importlib_resources import files; str(print(files('gseim_cpp_lib').joinpath('gseim_solver')))"` ./gseim_grc/src/gseim_cpp_lib/test_data/input/ac_controller_1.in ./gseim_grc/src/gseim/data
@@ -42,3 +43,8 @@ jobs:
         with:
           name: gseim-wheel
           path: gseim-*.whl
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage_report.dat

--- a/gseim_grc/src/.bazelrc
+++ b/gseim_grc/src/.bazelrc
@@ -1,1 +1,4 @@
 test --test_output=errors
+
+coverage --combined_report=lcov
+coverage --instrument_test_targets

--- a/gseim_grc/src/gseim_cpp_lib/BUILD
+++ b/gseim_grc/src/gseim_cpp_lib/BUILD
@@ -11,6 +11,7 @@ filegroup(
 cc_library(
     name = "gseim_solver_lib",
     srcs = [
+        "gseim_solver.cpp",
         "cctfile.cpp",
         "global.cpp",
         "utils.cpp",
@@ -36,6 +37,7 @@ cc_library(
         "//gseim:subxbe_cpp",
     ],
     hdrs = [
+        "gseim_solver.h",
         "cctfile.h",
         "global.h",
         "utils.h",
@@ -65,7 +67,7 @@ cc_library(
 
 cc_binary(
     name = "gseim_solver",
-    srcs = ["gsmain.cpp"],
+    srcs = ["main.cpp"],
     deps = [
         ":gseim_solver_lib"
     ],
@@ -74,6 +76,20 @@ cc_binary(
     ],
     copts = ["-std=c++17"],
     visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "gseim_solver_test_cpp",
+    srcs = ["gseim_solver_test.cpp"],
+    deps = [
+        ":gseim_solver_lib",
+    ],
+    data = [
+        "//gseim:element_data",
+    ] + glob([
+        "test_data/**",
+    ]),
+    copts = ["-std=c++17"],
 )
 
 py_test(

--- a/gseim_grc/src/gseim_cpp_lib/gseim_solver.cpp
+++ b/gseim_grc/src/gseim_cpp_lib/gseim_solver.cpp
@@ -33,7 +33,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
-int main(int argc, char** argv) {
+int solve(int argc, char** argv) {
 
    fs::path element_dir;
 

--- a/gseim_grc/src/gseim_cpp_lib/gseim_solver.h
+++ b/gseim_grc/src/gseim_cpp_lib/gseim_solver.h
@@ -1,0 +1,8 @@
+#ifndef GSEIM_SOLVER_H
+#define GSEIM_SOLVER_H
+
+// Put most of `main` into a separate function so it can be tested by a C++
+// test suite. Otherwise, two `main` functions exist and cannot be tested.
+int solve(int argc, char** argv);
+
+#endif

--- a/gseim_grc/src/gseim_cpp_lib/gseim_solver_test.cpp
+++ b/gseim_grc/src/gseim_cpp_lib/gseim_solver_test.cpp
@@ -1,0 +1,60 @@
+#include <cstdio>
+#include <iostream>
+#include <filesystem>
+
+#include "gseim_cpp_lib/gseim_solver.h"
+
+using namespace std;
+
+namespace fs = std::filesystem;
+
+int diff(string fname1, string fname2) {
+    string diff_cmd = string("diff --unified ") + fname1.c_str() + " " + fname2.c_str();
+    FILE *fp = popen(diff_cmd.c_str(), "r");
+    if (fp == NULL) {
+        cout << "Could not run diff on files" << endl;
+    }
+
+    int buf_size = 255;
+    char buf[buf_size];
+    while (fgets(buf, buf_size, fp) != NULL) {
+        cout << buf;
+    }
+
+    int retcode = pclose(fp);
+    return retcode;
+}
+
+void test_solver(string fname) {
+    fs::path input_data_path = fs::current_path()/"gseim_cpp_lib"/"test_data"/"input"/fname;
+
+    string input_path_str = input_data_path.string();
+    const char* argv[] = {"MISSING", input_path_str.c_str()};
+
+    int retcode = solve(2, (char**)argv);
+    if (retcode != 0) {
+        cout << "solve for " << fname << " generated return code: " << retcode << endl;
+        exit(1);
+    }
+
+    fs::path output_path = fs::current_path()/"gseim_cpp_lib"/"test_data"/"input"/fname;
+    output_path.replace_extension("dat");
+
+    fs::path expected_output_path = fs::current_path()/"gseim_cpp_lib"/"test_data"/"output"/fname;
+    expected_output_path.replace_extension("dat");
+
+    retcode = diff(output_path.string(), expected_output_path.string());
+    if (retcode != 0) {
+        cout << "diff failed" << endl;
+        cout << "diff return code: " << retcode << endl;
+        exit(1);
+    }
+}
+
+int main() {
+    test_solver("ac_controller_1.in");
+    test_solver("buck.in");
+    test_solver("controlled_rectifier_2.in");
+
+    return 0;
+}

--- a/gseim_grc/src/gseim_cpp_lib/main.cpp
+++ b/gseim_grc/src/gseim_cpp_lib/main.cpp
@@ -1,0 +1,5 @@
+#include "gseim_cpp_lib/gseim_solver.h"
+
+int main(int argc, char** argv) {
+    return solve(argc, argv);
+}


### PR DESCRIPTION
This commit adds coverage reporting to the Continuous Integration pipeline. It'll generate a `coverage_report.dat` artifact that can be used to generate an HTML report like this:

<img width="500" alt="Screen Shot 2022-08-14 at 2 16 38 PM" src="https://user-images.githubusercontent.com/14618/184555282-7bbd9c5d-6594-439b-9545-35d14e6e6816.png">

An example is attached to [this CI run](https://github.com/gseim/gseim/actions/runs/2857230984).

To generate the report, make sure you have the `lcov` package (`sudo apt install lcov`). Then, run `genhtml -o lcov_report [...path to coverage_report.dat]`. Open `lcov_report/index.html` in a browser. You can also run this locally `bazel coverage //...` and `genhtml -o lcov_report $(bazel info output_path)/_coverage/_coverage_report.dat`. In either case, make sure to run `genhtml` from `gseim_grc/src/` or it won't be able to find the source.

This is useful because it lets us see what code is actually exercised when we run the test suite. In this case, I see some code is never used (e.g. `Global::var_flag_string`), which means our test suite is either non-comprehensive, or the code is dead code.