### PR TITLE
Fix menubar on Mac

### DIFF
--- a/gseim_grc/src/grc/gui/Application.py
+++ b/gseim_grc/src/grc/gui/Application.py
@@ -116,14 +116,13 @@ class Application(Gtk.Application):
 
         # Setup the menu
         log.debug('Creating menu')
-        '''
         self.menu = Bars.Menu()
-        self.set_menu()
         if self.prefers_app_menu():
+            # Some Linux
             self.set_app_menu(self.menu)
         else:
+            # Mac, some Linux
             self.set_menubar(self.menu)
-        '''
 
     def do_activate(self):
         Gtk.Application.do_activate(self)

--- a/gseim_grc/src/grc/gui/MainWindow.py
+++ b/gseim_grc/src/grc/gui/MainWindow.py
@@ -75,10 +75,11 @@ class MainWindow(Gtk.ApplicationWindow):
         # Create the menu bar and toolbar
         generate_modes = platform.get_generate_options()
 
-        # This needs to be replaced
-        # Have an option for either the application menu or this menu
-        self.menu_bar = Gtk.MenuBar.new_from_model(Bars.Menu())
-        vbox.pack_start(self.menu_bar, False, False, 0)
+        # Only show the application menu at the top of the window if it's not
+        # shown in the menu bar separately from the app.
+        if app.prefers_app_menu():
+            self.menu_bar = Gtk.MenuBar.new_from_model(app.get_app_menu())
+            vbox.pack_start(self.menu_bar, False, False, 0)
 
         self.tool_bar = Bars.Toolbar()
         self.tool_bar.set_hexpand(True)


### PR DESCRIPTION
This hopefully has no impact on Ubuntu, but please confirm.

I attempted to resolve a note in the source about the menubar not being handled correctly:
```python
# This needs to be replaced
# Have an option for either the application menu or this menu
```

Now, on Mac, the menubar shows up at the top of the monitor, like a normal app, instead of as a toolbar in the app itself.

<img width="1051" alt="Screen Shot 2022-09-06 at 11 46 23 PM" src="https://user-images.githubusercontent.com/14618/188809077-91aa9cfb-cf82-439a-9e06-2c6dcc411e65.png">
