### PR TITLE
Add back missing xbel_name set

### DIFF
--- a/gseim_grc/src/gseim/gen_ebe.py
+++ b/gseim_grc/src/gseim/gen_ebe.py
@@ -179,7 +179,7 @@ void get_ebe(
     if (ebe_f_ptr_map.count(ebe_name) > 0) {
         (ebe_f_ptr_map.at(ebe_name))(G, X, J);
     } else {
-        cout << "get_ebe (alt): did not find " << ebe_name << endl;
+        cout << "get_ebe: did not find \\"" << ebe_name << "\\"" << endl;
         exit(1);
     }
 }

--- a/gseim_grc/src/gseim/gen_xbe.py
+++ b/gseim_grc/src/gseim/gen_xbe.py
@@ -178,7 +178,7 @@ void get_xbe(
     if (xbe_f_ptr_map.count(xbe_name) > 0) {
         (xbe_f_ptr_map.at(xbe_name))(G, X, J);
     } else {
-        cout << "get_xbe (alt): did not find " << xbe_name << endl;
+        cout << "get_xbe: did not find \\"" << xbe_name << "\\"" << endl;
         exit(1);
     }
 }

--- a/gseim_grc/src/gseim_cpp_lib/xbeusr.cpp
+++ b/gseim_grc/src/gseim_cpp_lib/xbeusr.cpp
@@ -49,6 +49,7 @@ void XbeUsr::set_values_1(
    tick[pos] = true; tick[pos+1] = true;
    i_xbel = find_name<XbeLib>(xbe_lib,s1);
    index_xbel = i_xbel;
+   xbel_name = xbe_lib[i_xbel].name;
    n_vr1 = xbe_lib[i_xbel].n_vr;
    vr.resize(n_vr1);
 


### PR DESCRIPTION
Hi Mahesh,

This commit fixes `master`. You removed this line from `xbeusr.cpp` in [4e906d1](https://github.com/gseim/gseim/commit/4e906d1dac6b97d7f4acb3a4b4004ef7ce841843):

```cpp
xbel_name = xbe_lib[i_xbel].name;
```

That line is important because I modified `subxbe.cpp:get_xbe` to build a `string`→`XbeFunc` map ([`std::map`](https://en.cppreference.com/w/cpp/container/map)) and use that to get the function that it needs to call. It's simpler to use a map than tracking the index in the library array. (It also removed the need for the `.lst` file that used to describe the order of elements.)

You saw the error:
```
get_xbe (alt): did not find
```
because the element name was never initialized, so it searched for an empty string. In this commit, I also made the error message clearer by adding quotes around the element name if it's not found. In the case of an empty string, it'll look like:
```
get_xbe: did not find ""
```