### PR TITLE
Fix references to d_slvparms in grc/gui/Application.py

### DIFF
--- a/gseim_grc/src/grc/gui/Application.py
+++ b/gseim_grc/src/grc/gui/Application.py
@@ -527,7 +527,7 @@ class Application(Gtk.Application):
                         self.display_message('solve block name should be a single word.')
                     else:
 
-                        slv = SolveBlock(flow_graph_1.d_slvparms, s_name, s_value)
+                        slv = SolveBlock(flow_graph_1.slvparms_ast, s_name, s_value)
                         flow_graph_1.l_solve_blocks.append(slv)
                         l_1 = sorted(flow_graph_1.l_solve_blocks, key=lambda x: x.index)
                         flow_graph_1.l_solve_blocks.clear()
@@ -678,8 +678,8 @@ class Application(Gtk.Application):
                             break
                 dialog.destroy()
 
-            for k, v in self.d_slvparms.items():
-                flow_graph_1.l_solve_blocks[i_active].d_parms[k] = v['default']
+            for k, v in self.slvparms_ast.parms.items():
+                flow_graph_1.l_solve_blocks[i_active].d_parms[k] = v.default
 
     def solve_pick_2(self, widget, flow_graph_1):
         if len(flow_graph_1.l_solve_blocks) == 0:


### PR DESCRIPTION
I noticed a bug in [bdc50ca](https://github.com/gseim/gseim/commit/bdc50ca0a832b336883e0d691f9057a53be82663) (PR #12). I left a few references to `d_slvparms` that should have been changed to `slvparms_ast`. This PR fixes that.

It should again be possible to create new solve blocks and reset solve blocks when more than one is present.

It'd be nice to have tests, will need to play with that.